### PR TITLE
Fix #2: Ensure trailing newline in as_markdown output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "todo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,9 @@ impl TodoList {
                 TodoListFileItem::TodoItem(i) => {
                     format!("- [{}] {}", i.state.as_markdown(), i.name)
                 }
-                TodoListFileItem::String(s) => s.to_string(),
+                TodoListFileItem::String(s) => format!("{s}\n"),
             })
-            .collect::<Vec<String>>()
-            .join("\n")
+            .collect::<String>()
     }
 
     pub fn get_item_mut(&mut self, item_number: usize) -> Result<&mut TodoItem, TodoError> {
@@ -352,4 +351,22 @@ pub enum TodoError {
     InvalidItemNumber(usize),
     #[error("IO Error. {0}")]
     FileIOError(#[from] io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_as_markdown_trailing_newline() {
+        let mut todo_list = TodoList::new("Test List");
+        todo_list.add_item("First item");
+        todo_list.add_item("Second item");
+
+        let markdown = todo_list.as_markdown();
+
+        // Check if the markdown ends with a newline
+        assert!(markdown.ends_with('\n'));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl TodoList {
             .iter()
             .map(|i| match i {
                 TodoListFileItem::TodoItem(i) => {
-                    format!("- [{}] {}", i.state.as_markdown(), i.name)
+                    format!("- [{}] {}\n", i.state.as_markdown(), i.name)
                 }
                 TodoListFileItem::String(s) => format!("{s}\n"),
             })


### PR DESCRIPTION
This PR fixes issue #2 by ensuring that the output of the as_markdown method ends with a trailing newline. A test has been added to verify this behavior.